### PR TITLE
Bug Fixing for 'ResumeParser.parseResumeFile is not a function'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 const parseIt = require('./utils/parseIt');
 var logger = require('tracer').colorConsole();
 
-module.exports.parseResume = function(inputFile, outputDir) {
+module.exports.parseResumeFile = function(inputFile, outputDir) {
   return new Promise((resolve, reject) => {
-    parseIt.parseResume(inputFile, outputDir, function(file, error) {
+    parseIt.parseResumeFile(inputFile, outputDir, function(file, error) {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
Got error message when using 'ResumeParser.parserResumeFile'.

>  TypeError: ResumeParser.parseResumeFile is not a function
    at Object.<anonymous> (/Users/ahmad/Sites/Mine9/js/cv-resume-parser/index.js:5:4)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3