### PR TITLE
Fix for mime-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,12 @@
   "main": "src/index.js",
   "author": "Parminder Klair",
   "contributors": [
-    {
-      "name": "Petar Petrov",
-      "url": "https://github.com/Mihaylov93"
-    }
+    "Petar Petrov (https://github.com/Mihaylov93)"
   ],
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/perminder-klair/resume-parser.git"
+    "url": "git+https://github.com/perminder-klair/resume-parser.git"
   },
   "bugs": {
     "url": "https://github.com/perminder-klair/resume-parser/issues"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/perminder-klair/resume-parser"
+    "url": "https://github.com/perminder-klair/resume-parser.git"
   },
   "bugs": {
     "url": "https://github.com/perminder-klair/resume-parser/issues"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Mihaylov93/resume-parser.git"
+    "url": "https://github.com/perminder-klair/resume-parser"
   },
   "bugs": {
-    "url": "https://github.com/Mihaylov93/resume-parser/issues"
+    "url": "https://github.com/perminder-klair/resume-parser/issues"
   },
   "homepage": "https://github.com/perminder-klair/resume-parser",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
   "name": "resume-parser",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Simple NodeJs library to parse Resume / CV to JSON.",
   "main": "src/index.js",
   "author": "Parminder Klair",
+  "contributors": [
+    {
+      "name": "Petar Petrov",
+      "url": "https://github.com/Mihaylov93"
+    }
+  ],
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/perminder-klair/resume-parser.git"
+    "url": "https://github.com/Mihaylov93/resume-parser.git"
   },
   "bugs": {
-    "url": "https://github.com/perminder-klair/resume-parser/issues"
+    "url": "https://github.com/Mihaylov93/resume-parser/issues"
   },
   "homepage": "https://github.com/perminder-klair/resume-parser",
   "keywords": [

--- a/src/utils/libs/processing.js
+++ b/src/utils/libs/processing.js
@@ -117,8 +117,8 @@ function cleanStr(str) {
 
 function PreparedFile(file, raw) {
   this.path = file;
-  this.mime = mime.getType(file);
-  this.ext = mime.getExtension(this.mime);
+  this.mime = mime.lookup(file);
+  this.ext = mime.extension(this.mime);
   this.raw = raw;
   this.name = path.basename(file);
 }


### PR DESCRIPTION
Merging the pr changing mime to mime-types broke the code

https://www.npmjs.com/package/mime
https://www.npmjs.com/package/mime-types

mime version 2 is a breaking change from 1.x as the semver implies. Specifically:

lookup() renamed to getType()
extension() renamed to getExtension()
charset() and load() methods have been removed

mime-types is similar to mime v1.x so the previous getType() and getExtension() give an error 